### PR TITLE
mock server-side render example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   * Reducer Hooks
   * Context Hooks (theme)
 * Component Mapping
+* Mock server-side rendering
 
 ## Available Scripts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2059,6 +2059,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz",
       "integrity": "sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ=="
     },
+    "babel-plugin-preval": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-preval/-/babel-plugin-preval-3.0.1.tgz",
+      "integrity": "sha512-s8hmTlRSmzcL7cHSIi0s6WxmpOAxfIlWqSVQwBIt7V5bNBaac+8JMZ6kJXLOazMJ8gCIcb5AJgQUgPHvbSYUzw==",
+      "requires": {
+        "babel-plugin-macros": "^2.2.2",
+        "require-from-string": "^2.0.2"
+      }
+    },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
@@ -3949,6 +3958,28 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
       "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA=="
+    },
+    "dangerously-set-inner-html": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dangerously-set-inner-html/-/dangerously-set-inner-html-2.0.1.tgz",
+      "integrity": "sha1-MpI/ywLA/IakEHBPEZ4/hQ4SHeI=",
+      "requires": {
+        "lodash.flatten": "^4.4.0",
+        "parse5": "^2.2.3",
+        "uuid": "^2.0.3"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY="
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        }
+      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -7878,6 +7909,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "babel-plugin-preval": "^3.0.1",
+    "dangerously-set-inner-html": "^2.0.1",
     "lodash": "^4.17.11",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import HOC from './examples/hoc'
 import Hooks from './examples/hooks'
 import ComponentMapping from './examples/component_mapping'
+import MockServerSideRender from './examples/mock_server_side_render'
 
 import './App.css';
 
@@ -14,6 +15,7 @@ function App() {
       <HOC />
       <Hooks />
       <ComponentMapping />
+      <MockServerSideRender />
     </div>
   );
 }

--- a/src/examples/mock_server_side_render/README.md
+++ b/src/examples/mock_server_side_render/README.md
@@ -1,0 +1,14 @@
+To mock server-side rendering I am converting a react component to just html & css.
+Thus, there isn't access to the browser's window object, react component state,
+click events, etc at runtime in the browser like a normal react component.
+
+To add that functionality back I'm using a script that grabs DOM nodes directly
+via an id or class to manipulate them. For example, the script can use the
+browser's window object and create click events even though the react component
+cannot.
+
+In other words, the react component would be turned into html & css on the server
+where there's no window object.
+
+Scripts injected via react's (really html5's) innerHTML will not execute so using
+`InnerHTML` of `dangerously-set-inner-html` to mock server-side rendering here.

--- a/src/examples/mock_server_side_render/ReactComponent.js
+++ b/src/examples/mock_server_side_render/ReactComponent.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default () => (
+  <div id='background' style={{ color: 'black', backgroundColor: 'white', width: 300 }}>
+    <section className='controls-section'>
+      <header>pick a theme</header>
+      <button id='light-theme-button'>light</button>
+      <button id='dark-theme-button'>dark</button>
+      <button className='close-button'>close</button>
+    </section>
+    <section id='preview-section' style={{ backgroundColor: 'gray', width: 300, height: 50 }}>
+      <div style={{ textAlign: 'center' }}>
+        <div> theme preview:</div>
+        <div id='display-name' />
+      </div>
+    </section>
+  </div>
+)

--- a/src/examples/mock_server_side_render/createMarkup.js
+++ b/src/examples/mock_server_side_render/createMarkup.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import ReactComponent from './ReactComponent'
+import preval from 'babel-plugin-preval/dist/macro'
+
+const script = preval`
+  const fs = require('fs');
+  const path = require('path');
+  module.exports = fs.readFileSync(path.join(__dirname, './script.js'), 'utf8');
+`
+
+export default function() {
+  const window = `
+    <script>
+      window.chicken = '"I want that chicken. Give me that chicken. -- Mara"';
+      window.mockServerSideRenderObject = { name: { first: 'Birdle Doo', middle: 'Burdle Buck', last: 'Chicken' } };
+    </script>
+  `
+  const logs = `
+    <script>
+      console.log('window.chicken: ', window.chicken);
+      console.log('window.mockServerSideRenderObject: ', window.mockServerSideRenderObject);
+    </script>
+  `
+
+  const reactComponent = renderToString(<ReactComponent />)
+
+  const scriptForReactComponent = `<script>${script};</script>`
+
+  return window + logs + reactComponent + scriptForReactComponent
+}

--- a/src/examples/mock_server_side_render/index.js
+++ b/src/examples/mock_server_side_render/index.js
@@ -1,9 +1,14 @@
 import React from 'react'
+import InnerHTML from 'dangerously-set-inner-html'
+import createMarkup from './createMarkup'
 
 export default function() {
+  console.log('html: ', createMarkup())
+
   return (
     <div className="Example">
       <header className="Example-header">Mock Server Side Render</header>
+      <InnerHTML html={createMarkup()} />
     </div>
   )
 }

--- a/src/examples/mock_server_side_render/index.js
+++ b/src/examples/mock_server_side_render/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function() {
+  return (
+    <div className="Example">
+      <header className="Example-header">Mock Server Side Render</header>
+    </div>
+  )
+}

--- a/src/examples/mock_server_side_render/script.js
+++ b/src/examples/mock_server_side_render/script.js
@@ -1,0 +1,89 @@
+(function() {
+  console.log('called mock server-side render script for react component')
+
+  // set theme colors
+  const lightColor = 'lightgray'
+  const darkColor = 'darkgray'
+  const defaultColor = 'white'
+  const COLOR_KEY = 'COLOR_KEY'
+
+  // create dom references
+  const background = document.getElementById("background")
+  const controlSection = document.querySelector(".controls-section")
+  const lightThemeButton = document.getElementById("light-theme-button")
+  const darkThemeButton = document.getElementById("dark-theme-button")
+  const closeButton = document.querySelector('.close-button')
+  const previewSection = document.getElementById("preview-section")
+  const displayArea = document.getElementById("display-name")
+
+  // grab name to display from browser's window object
+  if (displayArea) {
+    const name = window.mockServerSideRenderObject.name
+    const displayName = `${name.first} ${name.middle} ${name.last}`
+    displayArea.innerHTML = `<div>${displayName}</div>`
+  }
+
+  // use saved theme preference otherwise use default
+  const currentColor = localStorage.getItem(COLOR_KEY)
+  if (currentColor) {
+    previewSection && (previewSection.style.backgroundColor = currentColor)
+  } else {
+    previewSection && (previewSection.style.backgroundColor = defaultColor)
+  }
+
+  controlSection && controlSection.addEventListener("click", function(event) {
+    // log event
+    console.log('clicked controls section')
+
+    // remove section from dom
+    controlSection && controlSection.remove()
+  })
+
+  lightThemeButton && lightThemeButton.addEventListener("click", function(event) {
+    // log event
+    console.log('clicked light theme')
+
+    // stops bubbling click event to parent (control section)
+    // otherwise, its click events are triggered too
+    event.stopPropagation()
+
+    // set background color
+    previewSection && (previewSection.style.backgroundColor = lightColor)
+
+    localStorage.setItem(COLOR_KEY, lightColor)
+  });
+
+  darkThemeButton && darkThemeButton.addEventListener("click", function (event) {
+    // log action
+    console.log('clicked dark theme')
+
+    // stops bubbling click event to parent (control section)
+    // otherwise, its click events are triggered too
+    event.stopPropagation()
+
+    // set background color
+    previewSection && (previewSection.style.backgroundColor = darkColor)
+
+    localStorage.setItem(COLOR_KEY, darkColor)
+  });
+
+  closeButton && closeButton.addEventListener("click", function(event) {
+    // log action
+    console.log('clicked close button')
+
+    // stops bubbling click event to parent (control section)
+    // otherwise, its click events are triggered too
+    event.stopPropagation()
+
+    // remove section from dom
+    controlSection && controlSection.remove()
+  })
+
+  previewSection && previewSection.addEventListener("click", function(event) {
+    // log action
+    console.log('clicked preview section')
+
+    // add controls section back to dom
+    background && background.prepend(controlSection)
+  })
+})()


### PR DESCRIPTION
To mock server-side rendering I am converting a react component to just html & css.
Thus, there isn't access to the browser's window object, react component state,
click events, etc at runtime in the browser like a normal react component.

To add that functionality back I'm using a script that grabs DOM nodes directly
via an id or class to manipulate them. For example, the script can use the
browser's window object and create click events even though the react component
cannot.

In other words, the react component is turned into html & css on the server
where there's no window object.